### PR TITLE
Drilldown from gateway to meters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,18 @@ jobs:
           key: node-10-dependencies-{{ checksum "package-lock.json" }}
 
       - run: npm run test:unit
+
       - run: npm run build
       - run: tar -zcvf dist.tar.gz ./dist
+
+      - run: npm run build-no-auth
+      - run: tar -zcvf dist-no-auth.tar.gz ./dist-no-auth
 
       - store_artifacts:
           path: ~/repo/coverage
 
       - store_artifacts:
           path: ~/repo/dist.tar.gz
+
+      - store_artifacts:
+          path: ~/repo/dist-no-auth.tar.gz

--- a/.env.no-auth
+++ b/.env.no-auth
@@ -1,0 +1,2 @@
+NODE_ENV=production
+VUE_APP_SMF_NO_AUTH=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+/dist-no-auth
 
 # local env files
 .env.local

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+[![CircleCI](https://circleci.com/gh/solosTec/dash/tree/master.svg?style=shield)](https://circleci.com/gh/solosTec/dash/tree/master)
+
 # supported environment variables
 
 replace the smf server on development

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "build-no-auth": "vue-cli-service build --mode no-auth --dest dist-no-auth",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,7 @@
     mounted () {
       console.log('NODE_ENV: ' + process.env.NODE_ENV);
 
-      if (process.env.VUE_APP_SMF_NO_AUTH) {
+      if (process.env.VUE_APP_SMF_NO_AUTH === 'true') {
         this.$store.commit('user/loaded', {name: 'Admin', privs:[]});
         return;
       }

--- a/src/components/smf-table-data-mirror.vue
+++ b/src/components/smf-table-data-mirror.vue
@@ -91,7 +91,7 @@
                         label: 'Profile',
                         sortable: true,
                         class: 'text-right',
-                        formatter: (value, key, item) => {
+                        formatter: (value) => {
                             if (value === '8181c78610ff') return '1 minute values';
                             else if (value === '8181c78611ff') return '15 minute values';
                             else if (value === '8181c78612ff') return 'hourly values';

--- a/src/components/smf-table-data-mirror.vue
+++ b/src/components/smf-table-data-mirror.vue
@@ -26,7 +26,7 @@
     :filter="filter"
     @filtered="onFiltered"-->
 
-            <template slot="details" slot-scope="row">
+            <template v-slot:cell(details)="row">
                 <!--<b-button size="sm" @click="info(row.item, row.index, $event.target)" class="mr-1">
             Info modal
         </b-button>-->
@@ -35,7 +35,7 @@
                 </b-button>
             </template>
 
-            <template slot="row-details" slot-scope="row">
+            <template v-slot:cell(row-details)="row">
                 <b-card>
                     <ul>
                         <li v-for="(register, key) in row.item.registers" :key="key">{{ register | toRegisterName(true) }}</li>

--- a/src/components/smf-table-data-mirror.vue
+++ b/src/components/smf-table-data-mirror.vue
@@ -38,7 +38,7 @@
             <template slot="row-details" slot-scope="row">
                 <b-card>
                     <ul>
-                        <li v-for="(register, key) in row.item.registers" :key="key">{{ getRegisterName(register) }}</li>
+                        <li v-for="(register, key) in row.item.registers" :key="key">{{ register | toRegisterName(true) }}</li>
                     </ul>
                 </b-card>
             </template>
@@ -49,7 +49,6 @@
 </template>
 
 <script lang="js">
-
 
     export default {
         name: 'smf-table-data-mirror',
@@ -121,46 +120,6 @@
                 sortDesc: false,
                 sortDirection: 'desc',
             }
-        },
-        methods: { //0000600101FF
-            getRegisterName(reg) {
-                var name = reg.toUpperCase();
-                if (name === '8181C78203FF') return name + " - Hersteller-Identifikation";
-                else if (name === '8181C78205FF') return name + " - öffentlicher Schlüssel";
-                else if (name === '810000090B00') return name + " - Sekundenindex"; //  second index from meter
-                else if (name === '0100000009FF') return name + " - Geräteeinzelidentifikation";
-                else if (name === '0100000000FF') return name + " - Identifikationsnummer 1.0 ServerId -> Seriennummer";
-                else if (name === '0000600100FF') return name + " - Identifikationsnummer 2.1 Seriennummer";
-                else if (name === '0000600101FF') return name + " - Identifikationsnummer 2.2 Kundennummer";
-                else if (name === '0000601000FF') return name + " - Geraetename";
-                else if (name === '0000616100FF') return name + " - Fehlerregister";
-                else if (name === '0100010800FF') return name + " - Zaehlerstand Totalregister";
-                else if (name === '0100010801FF') return name + " - Zaehlerstand Tarif 1";
-                else if (name === '0100010802FF') return name + " - Zaehlerstand Tarif 2";
-                else if (name === '0100100700FF') return name + " - aktuelle Wirkleistung";
-                else if (name === '0100011100FF') return name + " - letzter signierter Total-Zaehlerstand";
-                else if (name === '0100240700FF') return name + " - Wirkleistung L1";
-                else if (name === '0100380700FF') return name + " - Wirkleistung L2";
-                else if (name === '01004C0700FF') return name + " - Wirkleistung L3";
-                else if (name === '010060320002') return name + " - Aktuelle Chiptemperatur";
-                else if (name === '010060320003') return name + " - Minimale Chiptemperatur";
-                else if (name === '010060320004') return name + " - Maximale Chiptemperatur";
-                else if (name === '010060320005') return name + " - Gemittelte Chiptemperatur";
-                else if (name === '010060320303') return name + " - Spannungsminimum";
-                else if (name === '010060320304') return name + " - Spannungsmaximum";
-                else if (name === '01001F0700FF') return name + " - Strom L1";
-                else if (name === '0100200700FF') return name + " - Spannung L1";
-                else if (name === '0100330700FF') return name + " - Strom L2";
-                else if (name === '0100340700FF') return name + " - Spannung L2";
-                else if (name === '0100470700FF') return name + " - Strom L3";
-                else if (name === '0100480700FF') return name + " - Spannung L3";
-                else if (name === '010000090B00') return name + " - Zeitstempel (UTC)";
-                else if (name === '0700030000FF') return name + " - Verbrauch in m³ (nicht korrigiert)";
-
-                return reg.toUpperCase();
-            }
-        },
-        computed: {
         }
     }
 </script>

--- a/src/components/smf-table-op-log.vue
+++ b/src/components/smf-table-op-log.vue
@@ -23,7 +23,7 @@
             class="shadow">
 
             <!-- A virtual column -->
-            <template slot="index" slot-scope="data">
+            <template v-slot:cell(index)="data">
                 {{ data.index + 1 + (nav.perPage * (nav.currentPage - 1)) }}
             </template>
 

--- a/src/components/smf-table-push-targets.vue
+++ b/src/components/smf-table-push-targets.vue
@@ -30,7 +30,7 @@
             <!--<template slot="row-details" slot-scope="row">
                 <b-card>
                     <ul>
-                        <li v-for="(register, key) in row.item.registers" :key="key">{{ getRegisterName(register) }}</li>
+                        <li v-for="(register, key) in row.item.registers" :key="key">{{ register | | toRegisterName(true) }}</li>
                     </ul>
                 </b-card>
             </template>-->
@@ -65,7 +65,7 @@
                         key: 'interval',
                         label: 'Interval',
                         sortable: true,
-                        formatter: (value, key, item) => {
+                        formatter: (value) => {
                             if (value > 60*60) return (value / (60*60)) + " h";
                             if (value > 60) return (value / 60) + " min";
                             return value + " sec";
@@ -76,7 +76,7 @@
                         key: 'delay',
                         label: 'Delay',
                         sortable: true,
-                        formatter: (value, key, item) => {
+                        formatter: (value) => {
                             if (value > 60*60) return (value / (60*60)) + " h";
                             if (value > 60) return (value / 60) + " min";
                             if (value === 0) return "-";
@@ -94,7 +94,7 @@
                         label: 'Service',
                         sortable: true,
                         class: 'text-right',
-                        formatter: (value, key, item) => {
+                        formatter: (value) => {
                             if (value === '8181c78a21ff') return 'IP-Telemetry';
                             else if (value === '8181c78a22ff') return 'Service Interface';
                             else if (value === '8181c78a23ff') return 'OBIS List';
@@ -115,7 +115,7 @@
                         key: "source",
                         label: "Push Source",
                         sortable: true,
-                        formatter: (value, key, item) => {
+                        formatter: (value) => {
                             if (value === '8181c78a42ff') return 'Push Source';
                             else if (value === '8181c78a43ff') return 'Install Parameters';
                             else if (value === '8181c78a44ff') return 'Visible Devices';
@@ -136,41 +136,6 @@
             }
         },
         methods: {
-            getRegisterName(reg) {
-                var name = reg.toUpperCase();
-                if (name === '8181C78203FF') return name + " - Hersteller-Identifikation";  //  Manufacturer
-                else if (name === '8181C78205FF') return name + " - öffentlicher Schlüssel";
-                else if (name === '810000090B00') return name + " - Sekundenindex"; //  second index from meter
-                else if (name === '0100000009FF') return name + " - Geräteeinzelidentifikation";
-                else if (name === '0100000000FF') return name + " - Identifikationsnummer 1.0 ServerId -> Seriennummer";
-                else if (name === '0000600100FF') return name + " - Identifikationsnummer 2.1 Seriennummer";
-                else if (name === '0000601000FF') return name + " - Geraetename";
-                else if (name === '0000616100FF') return name + " - Fehlerregister";
-                else if (name === '0100010800FF') return name + " - Zaehlerstand Totalregister";
-                else if (name === '0100010801FF') return name + " - Zaehlerstand Tarif 1";
-                else if (name === '0100010802FF') return name + " - Zaehlerstand Tarif 2";
-                else if (name === '0100100700FF') return name + " - aktuelle Wirkleistung";
-                else if (name === '0100011100FF') return name + " - letzter signierter Total-Zaehlerstand";
-                else if (name === '0100240700FF') return name + " - Wirkleistung L1";
-                else if (name === '0100380700FF') return name + " - Wirkleistung L2";
-                else if (name === '01004C0700FF') return name + " - Wirkleistung L3";
-                else if (name === '010060320002') return name + " - Aktuelle Chiptemperatur";
-                else if (name === '010060320003') return name + " - Minimale Chiptemperatur";
-                else if (name === '010060320004') return name + " - Maximale Chiptemperatur";
-                else if (name === '010060320005') return name + " - Gemittelte Chiptemperatur";
-                else if (name === '010060320303') return name + " - Spannungsminimum";
-                else if (name === '010060320304') return name + " - Spannungsmaximum";
-                else if (name === '01001F0700FF') return name + " - Strom L1";
-                else if (name === '0100200700FF') return name + " - Spannung L1";
-                else if (name === '0100330700FF') return name + " - Strom L2";
-                else if (name === '0100340700FF') return name + " - Spannung L2";
-                else if (name === '0100470700FF') return name + " - Strom L3";
-                else if (name === '0100480700FF') return name + " - Spannung L3";
-                else if (name === '010000090B00') return name + " - Zeitstempel (UTC)";
-                else if (name === '0700030000FF') return name + " - Verbrauch in m³ (nicht korrigiert)";
-
-                return reg.toUpperCase();
-            }
         },
         computed: {
         }

--- a/src/components/smf-table-push-targets.vue
+++ b/src/components/smf-table-push-targets.vue
@@ -21,7 +21,7 @@
                  class="shadow">
 
 
-            <template slot="details" slot-scope="row">
+            <template v-slot:cell(details)="row">
                 <b-button size="sm" @click="row.toggleDetails">
                     {{ row.detailsShowing ? 'Hide' : 'Show' }} Register
                 </b-button>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,15 +2,15 @@ import '@babel/polyfill'
 import 'mutationobserver-shim'
 import Vue from 'vue'
 import './plugins/bootstrap-vue'
-import './plugins/bootstrap-vue'
 import App from './App.vue'
 import router from './router'
 import vueHeadful from 'vue-headful'
 import Toasted from 'vue-toasted'
 import VueResource from 'vue-resource';
-import { i18n } from '@/plugins/i18n';
+import {i18n} from '@/plugins/i18n';
 import store from './store'
 import smfRowCountSelector from "@/components/smf-row-count-selector.vue";
+import './shared/formatter/registerNames';
 
 Vue.config.productionTip = false;
 Vue.component("vue-headful", vueHeadful);

--- a/src/router.js
+++ b/src/router.js
@@ -61,7 +61,7 @@ export default new Router({
                 component: smfConfigGateway
             },
             {
-                path: "/config/meter",
+                path: "/config/meter/:meterPk?",
                 name: "smfConfigMeter",
                 component: smfConfigMeter
             },

--- a/src/router.js
+++ b/src/router.js
@@ -61,7 +61,7 @@ export default new Router({
                 component: smfConfigGateway
             },
             {
-                path: "/config/meter/:meterPk?",
+                path: "/config/meter/:meterIdent?",
                 name: "smfConfigMeter",
                 component: smfConfigMeter
             },

--- a/src/shared/formatter/registerNames.ts
+++ b/src/shared/formatter/registerNames.ts
@@ -1,0 +1,48 @@
+import Vue from "vue";
+
+const TECK2NAME_MAP: Map<string, string> = new Map([
+    ['8181C78203FF', 'Hersteller-Identifikation'],
+    ['8181C78205FF', 'öffentlicher Schlüssel'],
+    ['810000090B00', 'Sekundenindex'], //  second index from meter
+    ['0100000009FF', 'Geräteeinzelidentifikation'],
+    ['0100000000FF', 'Identifikationsnummer 1.0 ServerId -> Seriennummer'],
+    ['0000600100FF', 'Identifikationsnummer 2.1 Seriennummer'],
+    ['0000601000FF', 'Geraetename'],
+    ['0000616100FF', 'Fehlerregister'],
+    ['0100010800FF', 'Zaehlerstand Totalregister'],
+    ['0100010801FF', 'Zaehlerstand Tarif 1'],
+    ['0100010802FF', 'Zaehlerstand Tarif 2'],
+    ['0100100700FF', 'aktuelle Wirkleistung'],
+    ['0100011100FF', 'letzter signierter Total-Zaehlerstand'],
+    ['0100240700FF', 'Wirkleistung L1'],
+    ['0100380700FF', 'Wirkleistung L2'],
+    ['01004C0700FF', 'Wirkleistung L3'],
+    ['010060320002', 'Aktuelle Chiptemperatur'],
+    ['010060320003', 'Minimale Chiptemperatur'],
+    ['010060320004', 'Maximale Chiptemperatur'],
+    ['010060320005', 'Gemittelte Chiptemperatur'],
+    ['010060320303', 'Spannungsminimum'],
+    ['010060320304', 'Spannungsmaximum'],
+    ['01001F0700FF', 'Strom L1'],
+    ['0100200700FF', 'Spannung L1'],
+    ['0100020800FF', 'negative Wirkenergie'],
+    ['0100020801FF', 'negative Wirkenergie - Tarif 1'],
+    ['0100020802FF', 'negative Wirkenergie - Tarif 2'],
+    ['0100330700FF', 'Strom L2'],
+    ['0100340700FF', 'Spannung L2'],
+    ['0100470700FF', 'Strom L3'],
+    ['0100480700FF', 'Spannung L3'],
+    ['010000090B00', 'Zeitstempel (UTC)'],
+    ['0700030000FF', 'Verbrauch in m³ (nicht korrigiert)']
+]);
+
+export function formatRegisterName(register: string, withName = false): string {
+    const name = register.toUpperCase();
+    const mappedName = TECK2NAME_MAP.get(name);
+    if (mappedName) {
+        return withName ? `${name} - ${mappedName}` : mappedName
+    }
+    return name;
+}
+
+Vue.filter('toRegisterName', formatRegisterName);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import Vuex, {Store} from "vuex";
+import Vuex from "vuex";
 import user, {UserState} from './modules/user';
 import websocket, {WebsocketState} from "./modules/websocket";
 

--- a/src/views/smf-config-gateway.vue
+++ b/src/views/smf-config-gateway.vue
@@ -85,7 +85,7 @@
                     <b-tabs pills card v-model="tabIndex">
 
                         <b-tab :title="$t('config-gateway-04')" active>
-                            <b-form v-on:submit.prevent>
+                            <b-form @submit.prevent="">
 
                                 <b-row>
                                     <b-col md="10" class="shadow">
@@ -193,7 +193,7 @@
                                 {{ $t('config-gateway-10') }}
                                 <b-spinner v-if="spinner.ipt" type="grow" small />
                             </template>
-                            <b-form v-on:submit.prevent>
+                            <b-form @submit.prevent="">
 
                                 <b-row>
                                     <b-col md="6" class="border">
@@ -451,13 +451,13 @@
                                     <b-button size="sm"
                                               @click="onMeterActivate(row.item, row.index, $event.target)">{{ row.item.active ? '✖ Deactivate' : '✔ Activate' }}</b-button>
                                 </template>
-                                <!--<template slot="edit" slot-scope="row">
+                                <template slot="edit" slot-scope="row">
                                     <b-button size="sm"
                                               variant="info"
                                               v-b-tooltip.hover :title="'meter code: ' + row.item.mc"
                                               :disabled="btnEditStatus(row.item.mc)"
                                               @click="onMeterEdit(row.item, row.index, $event.target)">{{ btnEdit }}</b-button>
-                                </template>-->
+                                </template>
                             </b-table>
                             <div>
                                 <b-link :href="meters.csv" download="meters.csv" type="text/csv">{{ linkMeterDownloadTitle }}</b-link>
@@ -471,7 +471,7 @@
                                 <b-spinner v-if="spinner.wmbus" type="grow" small />
                             </template>
 
-                            <b-form v-on:submit.prevent class="p-3 shadow">
+                            <b-form @submit.prevent="" class="p-3 shadow">
 
                                 <b-row>
 
@@ -529,7 +529,7 @@
                                     <b-col md="3">
                                         <b-form-group :label="$t('config-gateway-44')" label-for="smf-gw-wmbus-smode">
                                             <b-input-group>
-                                                <b-form-input :disabled="wmbus.protocol != 'A'"
+                                                <b-form-input :disabled="wmbus.protocol !== 'A'"
                                                               id="smf-gw-wmbus-smode"
                                                               type="number"
                                                               v-model.number="wmbus.sMode"
@@ -545,7 +545,7 @@
 
                                         <b-form-group :label="$t('config-gateway-46')" label-for="smf-gw-wmbus-tmode">
                                             <b-input-group>
-                                                <b-form-input :disabled="wmbus.protocol != 'A'"
+                                                <b-form-input :disabled="wmbus.protocol !== 'A'"
                                                               id="smf-gw-wmbus-tmode"
                                                               type="number"
                                                               v-model.number="wmbus.tMode"
@@ -623,7 +623,7 @@
                                 <b-spinner v-if="spinner.iec" type="grow" small />
                             </template>
 
-                            <b-form v-on:submit.prevent v-bind:class="{ 'bg-warning' : !iec.params.active }">
+                            <b-form @submit.prevent="" v-bind:class="{ 'bg-warning' : !iec.params.active }">
 
                                 <b-row class="p-3">
                                     <b-col md="3">
@@ -781,7 +781,7 @@
 
                         <!-- logs -->
                         <b-tab no-body title="Log">
-                            <b-form v-on:submit.prevent class="p-3">
+                            <b-form @submit.prevent="" class="p-3">
                                 <b-row>
                                     <b-col md="6">
                                         <b-form-group description="Select the time range">
@@ -805,7 +805,7 @@
                 </b-col>
 
                 <b-col md="2" class="p-3 bg-light">
-                    <b-form v-on:submit.prevent>
+                    <b-form @submit.prevent="">
                         <!-- bg-warning -->
                         <b-alert show dismissible class="bg-warning" v-if="mode === 'production'">
                             <span style="font-weight: bold">Note:</span> No other IP-T connection can be active during the execution of the requests below.
@@ -935,9 +935,9 @@ export default  {
           {
             key: 'online',
             label: "Online",
-            formatter: (value, key, item) => {
-                if (value == 0)  return '║';
-                else if (value == 1)  return '⊶';
+            formatter: (value) => {
+                if (value === 0)  return '║';
+                else if (value === 1)  return '⊶';
                 return '⇆';
             },
             class: 'text-center',
@@ -1047,7 +1047,7 @@ export default  {
                     key: 'meter',
                     label: 'Meter',
                     sortable: true,
-                    formatter: (value, key, item) => {
+                    formatter: (value) => {
                         return Boolean(value) ? value.toUpperCase() : '?';
                     }
                 },
@@ -1055,7 +1055,7 @@ export default  {
                     key: 'maker',
                     label: 'Maker',
                     sortable: true,
-                    formatter: (value, key, item) => {
+                    formatter: (value) => {
                         return (value) ? value : '-';
                     }
                 },
@@ -1063,7 +1063,7 @@ export default  {
                     key: 'lastSeen',
                     label: 'Last Seen',
                     sortable: true,
-                    formatter: (value, key, item) => {
+                    formatter: (value) => {
                         return value.toLocaleString()
                     }
                 },
@@ -1071,7 +1071,7 @@ export default  {
                     key: 'type',
                     label: 'Type',
                     sortable: true,
-                    formatter: (value, key, item) => {
+                    formatter: (value) => {
                         switch (value) {
                             case 0: return "M-Bus (wired)";
                             case 1: return "M-Bus (radio)";
@@ -1106,11 +1106,11 @@ export default  {
                     //formatter: (value, key, item) => {
                     //    return item.pk;
                     //}
+                },
+                {
+                    key: 'edit',
+                    label: 'Edit'
                 }
-                //{
-                //    key: 'edit',
-                //    label: 'Edit'
-                //}
             ],
             sortBy: 'meter',
             sortDesc: false,
@@ -1143,7 +1143,7 @@ export default  {
                     key: 'active',
                     label: 'Active',
                     sortable: true,
-                    formatter: (value, key, item) => {
+                    formatter: (value) => {
                         if (value)  return '✔';
                         return '✖';
                     },
@@ -1219,7 +1219,7 @@ export default  {
                     key: '8181C7930DFF',
                     label: 'P1',
                     sortable: false,
-                    formatter: (value, key, item) => {
+                    formatter: (value) => {
                         if (value)  return value;
                         return '-';
                     }
@@ -1228,7 +1228,7 @@ export default  {
                     key: '8181C7930EFF',
                     label: 'W5',
                     sortable: false,
-                    formatter: (value, key, item) => {
+                    formatter: (value) => {
                         if (value)  return value;
                         return '-';
                     }
@@ -1270,7 +1270,7 @@ export default  {
     },
 
     methods: {
-        ws_on_open(path) {
+        ws_on_open() {
             this.gateways = [];
             this.ws_subscribe("config.gateway");
             this.ws_subscribe("table.gateway.count");
@@ -1279,13 +1279,13 @@ export default  {
         ws_on_data(obj) {
             if (obj.cmd != null) {
             // console.log('websocket received ' + obj.cmd);
-                if (obj.cmd == 'update') {
+                if (obj.cmd === 'update') {
                     if (obj.channel != null) {
                         // console.log('update channel ' + obj.channel);
-                        if (obj.channel == MESSAGE_TYPES.getProcParameter) {
+                        if (obj.channel === MESSAGE_TYPES.getProcParameter) {
                             //console.log("section :::" + obj.section + ":::");
                             //console.log(obj.rec.values);
-                            if (obj.section == SML_CODES.CLASS_OP_LOG_STATUS_WORD) {
+                            if (obj.section === SML_CODES.CLASS_OP_LOG_STATUS_WORD) {
                                 //  hide loading spinner
                                 this.spinner.status = false;
                                 this.gw.status = [];
@@ -1346,14 +1346,14 @@ export default  {
                                     this.gw.status.push({ value: 'NTP is running (Time base is secure)', variant: "success" });
                                 }
                             }
-                            else if (obj.section == SML_CODES.CODE_ROOT_VISIBLE_DEVICES) {
-                                Object.values(obj.rec.values).forEach((e, idx, a) => {
+                            else if (obj.section === SML_CODES.CODE_ROOT_VISIBLE_DEVICES) {
+                                Object.values(obj.rec.values).forEach((e) => {
                                     //console.log(e);
-                                    var lastSeenVisible = (e[SML_CODES.CURRENT_UTC] != null)
+                                    const lastSeenVisible = (e[SML_CODES.CURRENT_UTC] != null)
                                         ? new Date(e[SML_CODES.CURRENT_UTC].substring(0, 19))
                                         : new Date();
 
-                                    var recVisible = {
+                                    const recVisible = {
                                         nr: e.nr,
                                         ident: e[SML_CODES.CODE_SERVER_ID],
                                         meter: e.serial,
@@ -1372,15 +1372,15 @@ export default  {
 
                                 });
                             }
-                            else if (obj.section == SML_CODES.CODE_ROOT_ACTIVE_DEVICES) {
+                            else if (obj.section === SML_CODES.CODE_ROOT_ACTIVE_DEVICES) {
                                 //  hide loading spinner
                                 this.spinner.meters = false;
 
-                                Object.values(obj.rec.values).forEach((e, idx, a) => {
+                                Object.values(obj.rec.values).forEach((e) => {
                                     //console.log(e);
-                                    var recActive = this.meters.values.find(meter => {
+                                    let recActive = this.meters.values.find(meter => {
                                         //console.log('active device: compare ' + meter.ident + ' <> ' + e[SML_CODES.CODE_SERVER_ID]);
-                                        if (meter.ident == e[SML_CODES.CODE_SERVER_ID]) {
+                                        if (meter.ident === e[SML_CODES.CODE_SERVER_ID]) {
                                             meter.active = true;
                                             meter.pk = obj.rec.values.pk;
                                             meter.mc = obj.rec.values.mc;
@@ -1425,7 +1425,7 @@ export default  {
                                 //
                                 this.meterTableComplete();
                             }
-                            else if (obj.section == SML_CODES.CODE_ROOT_DEVICE_IDENT) {
+                            else if (obj.section === SML_CODES.CODE_ROOT_DEVICE_IDENT) {
                                 //  hide loading spinner
                                 this.spinner.firmware = false;
                                 //  firmware
@@ -1434,9 +1434,9 @@ export default  {
                                 const srv = obj.rec.values['8181C78204FF'];
                                 const values = Object.values(obj.rec.values['8181C78206FF']);
                                 //console.log(values);
-                                values.forEach((e, idx, a) => {
+                                values.forEach((e, idx) => {
                                     //console.log(e);
-                                    var rec = {
+                                    const rec = {
                                         nr: idx,
                                         name: e['8181C78208FF'],
                                         version: e['818100020000'],
@@ -1446,19 +1446,19 @@ export default  {
                                     this.fw.values.push(rec);
                                 });
                             }
-                            else if (obj.section == SML_CODES.CODE_ROOT_MEMORY_USAGE) {
+                            else if (obj.section === SML_CODES.CODE_ROOT_MEMORY_USAGE) {
                                 //  hide loading spinner
                                 this.spinner.memory = false;
                                 this.gw.memory.mirror = obj.rec.values['0080800011FF'];
                                 this.gw.memory.tmp = obj.rec.values['0080800012FF'];
                             }
-                            else if (obj.section == SML_CODES.CODE_ROOT_W_MBUS_STATUS) {
+                            else if (obj.section === SML_CODES.CODE_ROOT_W_MBUS_STATUS) {
                                 this.wmbus.type = obj.rec.values['810600000100'];
-                                this.wmbus.id = obj.rec.values['810600000300']
+                                this.wmbus.id = obj.rec.values['810600000300'];
                                 this.wmbus.firmware = obj.rec.values['810600020000'];
                                 this.wmbus.hardware = obj.rec.values['8106000203FF'];
                             }
-                            else if (obj.section == SML_CODES.CODE_IF_wMBUS) {
+                            else if (obj.section === SML_CODES.CODE_IF_wMBUS) {
                                 //  hide loading spinner
                                 this.spinner.wmbus = false;
 
@@ -1481,12 +1481,12 @@ export default  {
                                 this.wmbus.sMode = obj.rec.values[SML_CODES.W_MBUS_MODE_S];
                                 this.wmbus.tMode = obj.rec.values[SML_CODES.W_MBUS_MODE_T];
                             }
-                            else if (obj.section == SML_CODES.CODE_ROOT_IPT_STATE) {
+                            else if (obj.section === SML_CODES.CODE_ROOT_IPT_STATE) {
                                 this.ipt.status.host = obj.rec.values['814917070000'];
                                 this.ipt.status.local = obj.rec.values['81491A070000'];
                                 this.ipt.status.remote = obj.rec.values['814919070000'];
                             }
-                            else if (obj.section == SML_CODES.CODE_ROOT_IPT_PARAM) {
+                            else if (obj.section === SML_CODES.CODE_ROOT_IPT_PARAM) {
                                 //console.log(obj.rec.values);
                                 //  hide loading spinner
                                 this.spinner.ipt = false;
@@ -1500,7 +1500,7 @@ export default  {
                                 this.ipt.param[1].user = obj.rec.values['81490D070002']['8149633C0102'];
                                 this.ipt.param[1].pwd = obj.rec.values['81490D070002']['8149633C0202'];
                             }
-                            else if (obj.section == SML_CODES.CODE_IF_1107) {
+                            else if (obj.section === SML_CODES.CODE_IF_1107) {
                                 //  hide loading spinner
                                 this.spinner.iec = false;
 
@@ -1520,13 +1520,13 @@ export default  {
                                 this.iec.params.devices = Array.from(obj.rec.values['8181C79309FF']);
 
                             }
-                            else if (obj.section == SML_CODES.CODE_DEVICE_CLASS) {
+                            else if (obj.section === SML_CODES.CODE_DEVICE_CLASS) {
                                 console.log('update channel ' + obj.channel + ' ToDo: ' + obj.section);
                             }
-                            else if (obj.section == SML_CODES.DATA_MANUFACTURER) {
+                            else if (obj.section === SML_CODES.DATA_MANUFACTURER) {
                                 console.log('update channel ' + obj.channel + ' ToDo: ' + obj.section);
                             }
-                            else if (obj.section == SML_CODES.CODE_SERVER_ID) {
+                            else if (obj.section === SML_CODES.CODE_SERVER_ID) {
                                 console.log('update channel ' + obj.channel + ' ToDo: ' + obj.section);
                             }
                             else {
@@ -1534,20 +1534,20 @@ export default  {
 
                             }
                         }
-                        else if (obj.channel == MESSAGE_TYPES.getProfileList) {
+                        else if (obj.channel === MESSAGE_TYPES.getProfileList) {
                             //console.log("section :::" + obj.section + ":::");
                             //console.log(obj);
                             //console.log(obj.rec.values);
                             console.log(obj.rec.values['8181C789E2FF'] + ", size: "+ this.tabOpLog.data.items.length);
-                            if (obj.section == SML_CODES.CLASS_OP_LOG) {
+                            if (obj.section === SML_CODES.CLASS_OP_LOG) {
 
                                 //  get timestamp
-                                var utc = (obj.rec.values['010000090B00'] != null)
+                                const utc = (obj.rec.values['010000090B00'] != null)
                                     ? new Date(obj.rec.values['010000090B00'].substring(0, 19))
                                     : new Date();
 
                                 //  build record
-                                var rec = {
+                                let rec = {
                                     index: this.tabOpLog.data.items.length,
                                     status: obj.rec.values.status,
                                     event: obj.rec.values['8181C789E2FF'],
@@ -1568,9 +1568,9 @@ export default  {
                                 console.error('update channel ' + obj.channel + ' with unknown section ' + obj.section);
                             }
                         }
-                        else if (obj.channel == 'attention.code') {
+                        else if (obj.channel === 'attention.code') {
                             // Vue.toasted.show('ATTENTION please!');
-                            if (obj.section == '8181c7c7fd00') {
+                            if (obj.section === '8181c7c7fd00') {
                                 //  OK
                                 this.$toasted.global.sml_attention_ok(obj.rec.srv + " modification accepted", "info");
                             }
@@ -1587,7 +1587,7 @@ export default  {
                             this.spinner.wmbus = false;
                             this.spinner.iec = false;
                         }
-                        else if (obj.channel == 'table.gateway.count') {
+                        else if (obj.channel === 'table.gateway.count') {
                             //  unused
                         }
                         else {
@@ -1595,8 +1595,8 @@ export default  {
                         }
                     }
                 }
-                else if (obj.cmd == 'insert') {
-                    var rec = {
+                else if (obj.cmd === 'insert') {
+                    let rec = {
                         pk: obj.rec.key.pk,
                         serverId: obj.rec.data.serverId,
                         manufacturer: obj.rec.data.manufacturer,
@@ -1608,19 +1608,19 @@ export default  {
                         userPwd: obj.rec.data.userPwd,
                         online: obj.rec.data.online };
 
-                    if (obj.rec.data.online == 1) {
+                    if (obj.rec.data.online === 1) {
                         rec["_rowVariant"] = 'success';
                     }
-                    else if (obj.rec.data.online == 2) {
+                    else if (obj.rec.data.online === 2) {
                         rec["_rowVariant"] = 'warning';
                     }
 
                     this.gateways.push(rec);
                 }
-                else if (obj.cmd == 'modify') {
+                else if (obj.cmd === 'modify') {
                     console.log('lookup gateway ' + obj.key);
                     this.gateways.find(function(rec) {
-                        if(rec.pk == obj.key) {
+                        if(rec.pk === obj.key) {
                             console.log('modify record ' + rec.name);
                             if (obj.value.serverId != null) {
                                 rec.serverId = obj.value.serverId;
@@ -1639,11 +1639,11 @@ export default  {
                             }
                             else if (obj.value.online != null) {
                                 rec.online = obj.value.online;
-                                if (obj.value.online == 1) {
+                                if (obj.value.online === 1) {
                                     //  cause possibly an update problem
                                     rec["_rowVariant"] = 'success';
                                 }
-                                else if (obj.value.online == 2) {
+                                else if (obj.value.online === 2) {
                                     rec["_rowVariant"] = 'warning';
                                 }
                                 else {
@@ -1655,24 +1655,24 @@ export default  {
                         }
                     });
                 }
-                else if (obj.cmd == 'clear') {
+                else if (obj.cmd === 'clear') {
                     //  clear table
                     this.gateways = [];
                     this.meters.values = [];
                     this.tabOpLog.data.items = [];
                 }
-                else if (obj.cmd == 'delete') {
-                    var idx = this.gateways.findIndex(rec => rec.pk == obj.key);
+                else if (obj.cmd === 'delete') {
+                    const idx = this.gateways.findIndex(rec => rec.pk === obj.key);
                     console.log('delete index ' + idx);
                     this.gateways.splice(idx, 1);
                 }
-                else if (obj.cmd == 'load') {
+                else if (obj.cmd === 'load') {
                     //  load status
                     if (obj.show != null) {
                         console.log('load state ' + obj.show);
                         this.isBusy = obj.show;
                     }
-                    else if (obj.level != 0) {
+                    else if (obj.level !== 0) {
                         this.busyLevel = obj.level;
                     }
                 }
@@ -1686,7 +1686,7 @@ export default  {
         },
 
         rowSelected(items) {
-            this.selected = items
+            this.selected = items;
             if (items.length > 0) {
                 console.log('selected ' + items[0].serverId);
                 // console.log(items.length + ' rows selected ');
@@ -1708,17 +1708,17 @@ export default  {
                 //
                 //  1 gateway selected
                 //
-                if (items.length == 1) {
-                    var self = this;
+                if (items.length === 1) {
+                    const self = this;
                     this.options.selected.forEach(option => {
                         //  channels: ['Status Word', 'Meters', 'Firmware', 'Memory', 'wireless M-Bus', 'IP-Telemtry', 'IEC'],
                         //console.log('option: ' + option);
-                        if (option == 'status-word') {
+                        if (option === 'status-word') {
                             //  810060050000
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CLASS_OP_LOG_STATUS_WORD, [items[0].pk]);
                             self.spinner.status = true;
                         }
-                        else if (option == 'devices') {
+                        else if (option === 'devices') {
                             //gw_req_vec.push("root-visible-devices");
                             //gw_req_vec.push("root-active-devices");
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CODE_ROOT_VISIBLE_DEVICES, [items[0].pk]);
@@ -1727,37 +1727,37 @@ export default  {
                             self.meters.values = [];
                             self.spinner.meters = true;
                         }
-                        else if (option == 'firmware') {
+                        else if (option === 'firmware') {
                             //gw_req_vec.push("root-device-id");
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CODE_ROOT_DEVICE_IDENT, [items[0].pk]);
                             self.fw.values = []; // ? self
                             self.spinner.firmware = true;
                         }
-                        else if (option == 'memory-usage') {
+                        else if (option === 'memory-usage') {
                             //gw_req_vec.push("root-memory-usage");
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CODE_ROOT_MEMORY_USAGE, [items[0].pk]);
                             self.spinner.memory = true;
                         }
-                        else if (option == 'w-MBus') {
+                        else if (option === 'w-MBus') {
                             //gw_req_vec.push("root-wMBus-status");
                             //gw_req_vec.push("IF-wireless-mbus");
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CODE_ROOT_W_MBUS_STATUS, [items[0].pk]);
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CODE_IF_wMBUS, [items[0].pk]);
                             self.spinner.wmbus = true;
                         }
-                        else if (option == 'ipt') {
+                        else if (option === 'ipt') {
                             //gw_req_vec.push("root-ipt-state");
                             //gw_req_vec.push("root-ipt-param");
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CODE_ROOT_IPT_PARAM, [items[0].pk]);
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CODE_ROOT_IPT_STATE, [items[0].pk]);
                             self.spinner.ipt = true;
                         }
-                        else if (option == 'iec') {
+                        else if (option === 'iec') {
                             //gw_req_vec.push("IF-IEC-62505-21");
                             self.ws_submit_request(MESSAGE_TYPES.getProcParameter, SML_CODES.CODE_IF_1107, [items[0].pk]);
                             self.spinner.iec = true;
                         }
-                        else if (option == 'log') {
+                        else if (option === 'log') {
                             //   SML_GetProfileList_Req
                             //  request operation log: 81 81 C7 89 E1 FF (OBIS_CLASS_OP_LOG)
                             //console.log("selected: " + this.tabOpLog.form.selected);
@@ -1867,7 +1867,7 @@ export default  {
 
         onFiltered(filteredItems) {
             // Trigger pagination to update the number of buttons/pages due to filtering
-            this.visibleRows = filteredItems.length
+            this.visibleRows = filteredItems.length;
             this.currentPage = 1
         },
 
@@ -1884,7 +1884,7 @@ export default  {
                 [this.form.pk],
                 { ipt: this.ipt.param });
         },
-        onMeterDelete(item, index, button) {
+        onMeterDelete(item) {
             // alert("delete: " + item.ident);
             //this.ws_submit_command("com:sml",
             //    "set.proc.param",
@@ -1900,7 +1900,7 @@ export default  {
                 [this.form.pk],
                 { nr: item.nr, meter: item.ident });
         },
-        onMeterActivate(item, index, button) {
+        onMeterActivate(item) {
             if (item.active) {
                 //this.ws_submit_command("com:sml",
                 //    "set.proc.param",
@@ -1932,11 +1932,11 @@ export default  {
                     { nr: item.nr, meter: item.ident });
             }
         },
-        //onMeterEdit(item, index, button) {
-        //    console.log("onMeterEdit " + item.pk + " : " + item.serverId);
-        //    //  route to meter configuration
-        //    this.$router.push({ name: 'smfConfigMeter' });
-        //},
+        onMeterEdit(item) {
+           console.log("onMeterEdit " + item.pk + " : " + item.serverId);
+           //  route to meter configuration
+           this.$router.push({ name: 'smfConfigMeter', params: { meterPk: item.pk  }});
+        },
         onWMbusUpdate() {
             //this.ws_submit_command("com:sml",
             //    "set.proc.param",
@@ -1963,19 +1963,18 @@ export default  {
         },
 
         meterTableComplete() {
-            var csv = 'Ident;Meter;Maker;ServerId\n';
+            let csv = 'Ident;Meter;Maker;ServerId\n';
             this.meters.values.forEach(function(row) {
                 //console.log(row.ident);
                 csv += row.ident + ';' + row.meter + ';' + row.maker + ';' + row.serverId + '\n';
             });
-            var data = new Blob([csv]);
+            const data = new Blob([csv]);
             this.meters.csv = URL.createObjectURL(data);
         },
         btnEditStatus(mc) {
             //console.log("btnEditStatus " + mc);
             if (typeof mc == 'undefined') return true;
-            if ((mc.length > 2) && mc.startsWith("MC")) return true;
-            return false;
+            return (mc.length > 2) && mc.startsWith("MC");
         }
    },
 
@@ -1990,19 +1989,19 @@ export default  {
             return "Update";
         },
         btnDeleteTitle() {
-            if (this.selected.length == 0)  {
+            if (this.selected.length === 0)  {
                 return "Delete";
             }
-            else if(this.selected.length == 1) {
+            else if(this.selected.length === 1) {
                 return "Delete " + this.selected[0].name;
             }
             return "Delete " + this.selected.length + " gateway(s)";
         },
         btnRebootTitle() {
-            if (this.selected.length == 0)  {
+            if (this.selected.length === 0)  {
                 return "Reboot";
             }
-            else if(this.selected.length == 1) {
+            else if(this.selected.length === 1) {
                 return "Reboot " + this.selected[0].name;
             }
             return "Reboot " + this.selected.length + " gateway(s)";
@@ -2011,17 +2010,17 @@ export default  {
             return "Edit";
         },
         isRecordSelected() {
-            return this.selected.length != 0;
+            return this.selected.length !== 0;
         },
         isRecordNew() {
-            if (this.selected.length != 0) {
-                return this.form.name != this.selected[0].name;
+            if (this.selected.length !== 0) {
+                return this.form.name !== this.selected[0].name;
             }
             return this.form.name.length > 0;
         },
         serverIdValidation() {
             if (this.form.serverId == null) return false;
-            var rex = /[0-9A-Fa-f]{14}/g;   //  test for hexadecimal string with 14 characters
+            const rex = /[0-9A-Fa-f]{14}/g;   //  test for hexadecimal string with 14 characters
             return rex.test(this.form.serverId);
         },
         wmbusRebootPrep() {
@@ -2031,7 +2030,7 @@ export default  {
             else if (this.wmbus.reboot > 60) {
                 return (this.wmbus.reboot / 60).toFixed(2) + ' min';
             }
-            else if (this.wmbus.reboot == 0) {
+            else if (this.wmbus.reboot === 0) {
                 return 'OFF';
             }
             return this.wmbus.reboot + ' sec.';
@@ -2045,18 +2044,18 @@ export default  {
     },
 
     watch: {
-        'options.selected'(newVal, oldVal) {
+        'options.selected'(newVal) {
             //console.log('selected ' + newVal + ", " + oldVal);
             if (newVal.length === 0) {
-                this.options.indeterminate = false
-                this.options.allSelected = false
+                this.options.indeterminate = false;
+                this.options.allSelected = false;
             } else if (newVal.length === this.options.channels.length) {
-                this.options.indeterminate = false
-                this.options.allSelected = true
+                this.options.indeterminate = false;
+                this.options.allSelected = true;
             }
             else {
-                this.options.indeterminate = true
-                this.options.allSelected = false
+                this.options.indeterminate = true;
+                this.options.allSelected = false;
             }
         }
     },

--- a/src/views/smf-config-gateway.vue
+++ b/src/views/smf-config-gateway.vue
@@ -441,22 +441,22 @@
                                 :sort-direction="meters.sortDirection"
                                 class="shadow">
 
-                                <template slot="visible" slot-scope="row">
+                                <template v-slot:cell(visible)="row">
                                     <b-button size="sm"
                                               v-if="row.item.visible"
                                               @click="onMeterDelete(row.item, row.index, $event.target)">✔ Delete</b-button>
                                 </template>
 
-                                <template slot="active" slot-scope="row">
+                                <template v-slot:cell(active)="row">
                                     <b-button size="sm"
                                               @click="onMeterActivate(row.item, row.index, $event.target)">{{ row.item.active ? '✖ Deactivate' : '✔ Activate' }}</b-button>
                                 </template>
-                                <template slot="edit" slot-scope="row">
+                                <template v-slot:cell(edit)="row">
                                     <b-button size="sm"
                                               variant="info"
                                               v-b-tooltip.hover :title="'meter code: ' + row.item.mc"
                                               :disabled="btnEditStatus(row.item.mc)"
-                                              @click="onMeterEdit(row.item, row.index, $event.target)">{{ btnEdit }}</b-button>
+                                              @click="onMeterEdit(row.item)">{{ btnEdit }}</b-button>
                                 </template>
                             </b-table>
                             <div>
@@ -1517,7 +1517,8 @@ export default  {
                                 this.iec.params.timeSync = obj.rec.values['8181C79313FF'];
                                 this.iec.params.maxVar = obj.rec.values['8181C79314FF'];
                                 //  object
-                                this.iec.params.devices = Array.from(obj.rec.values['8181C79309FF']);
+                                const whatIsThis = obj.rec.values['8181C79309FF'];
+                                this.iec.params.devices = whatIsThis ? Array.from(whatIsThis) : [];
 
                             }
                             else if (obj.section === SML_CODES.CODE_DEVICE_CLASS) {
@@ -1933,9 +1934,7 @@ export default  {
             }
         },
         onMeterEdit(item) {
-           console.log("onMeterEdit " + item.pk + " : " + item.serverId);
-           //  route to meter configuration
-           this.$router.push({ name: 'smfConfigMeter', params: { meterPk: item.pk  }});
+           this.$router.push({ name: 'smfConfigMeter', params: { meterIdent: item.ident }});
         },
         onWMbusUpdate() {
             //this.ws_submit_command("com:sml",

--- a/src/views/smf-config-meter.vue
+++ b/src/views/smf-config-meter.vue
@@ -83,7 +83,7 @@
                 <b-col md="12" class="p-3 shadow">
                     <b-tabs pills card v-model="tabIndex">
                         <b-tab title="Configuration" active>
-                            <b-form v-on:submit.prevent>
+                            <b-form @:submit.prevent="">
                                 <b-row>
                                     <b-col md="3">
                                         <b-form-group label="Ident" label-for="smf-form-meter-ident">
@@ -115,8 +115,8 @@
                                         </b-form-group>
                                     </b-col>
                                     <b-col md="3">
-                                        <b-form-group label="Manufacturer" label-for="smf-form-meter-maker">
-                                            <b-form-input id="smf-form-meter-maker"
+                                        <b-form-group label="Manufacturer" label-for="smf-form-meter-maker-1">
+                                            <b-form-input id="smf-form-meter-maker-1"
                                                           type="text"
                                                           v-model="form.maker"
                                                           placeholder="<Manufacturer>" />
@@ -197,7 +197,7 @@
                                 <b-spinner v-if="spinner.readout" type="grow" small />
                             </template>
 
-                            <b-form v-on:submit.prevent>
+                            <b-form @:submit.prevent="">
                                 <b-row>
                                     <b-col md="6">
                                         <b-form-group label="Ident" label-for="smf-form-meter-ident-a">
@@ -269,7 +269,7 @@
                                 <b-spinner v-if="spinner.meter" type="grow" small />
                             </template>
 
-                            <b-form v-on:submit.prevent class="p-3 shadow">
+                            <b-form @:submit.prevent="" class="p-3 shadow">
                                 <b-row>
                                     <b-col md="9">
                                         <b-form-group label="Public Key" label-for="smf-form-meter-pubkey">
@@ -323,11 +323,11 @@
                                 </b-row>
                             </b-form>
 
-                            <b-form v-on:submit.prevent class="p-3">
+                            <b-form @:submit.prevent="" class="p-3">
                                 <b-row>
                                     <b-col md="3">
-                                        <b-form-group label="Device Class" label-for="smf-form-meter-class">
-                                            <b-form-input id="smf-form-meter-class"
+                                        <b-form-group label="Device Class" label-for="smf-form-device-class">
+                                            <b-form-input id="smf-form-device-class"
                                                           type="text"
                                                           v-model="tabMeter.data.devClass"
                                                           readonly
@@ -335,8 +335,8 @@
                                         </b-form-group>
                                     </b-col>
                                     <b-col md="3">
-                                        <b-form-group label="Manufacturer" label-for="smf-form-meter-maker">
-                                            <b-form-input id="smf-form-meter-maker"
+                                        <b-form-group label="Manufacturer" label-for="smf-form-meter-maker-2">
+                                            <b-form-input id="smf-form-meter-maker-2"
                                                           type="text"
                                                           v-model="tabMeter.data.maker"
                                                           readonly
@@ -394,7 +394,7 @@
                                 Push Operations
                                 <b-spinner v-if="spinner.push" type="grow" small />
                             </template>
-                            <b-form v-on:submit.prevent class="p-3">
+                            <b-form @:submit.prevent="" class="p-3">
                                 <b-row>
                                     <b-col md="6">
                                         <pushTargets ref="pushTargets" :items="tabPush.data.items" />
@@ -413,7 +413,7 @@
                                 Data Mirror
                                 <b-spinner v-if="spinner.mirror" type="grow" small />
                             </template>
-                            <b-form v-on:submit.prevent class="p-3">
+                            <b-form @:submit.prevent="" class="p-3">
                                 <b-row>
                                     <b-col md="6">
                                         <dataMirror ref="dataMirror" :items="tabDataMirror.data.items" />
@@ -505,7 +505,7 @@
                         key: 'tom',
                         label: 'TOM',
                         sortable: true,
-                        formatter: (value, key, item) => {
+                        formatter: (value) => {
                             return value.toUTCString();
                         }
                     },
@@ -538,9 +538,9 @@
                         key: 'online',
                         label: 'Online',
                         sortable: true,
-                        formatter: (value, key, item) => {
-                            if (value == 0) return '║';
-                            else if (value == 1) return '⊶';
+                        formatter: (value) => {
+                            if (value === 0) return '║';
+                            else if (value === 1) return '⊶';
                             return '⇆';
                         },
                         class: 'text-center'
@@ -588,7 +588,7 @@
                             key: 'unit',
                             label: 'Unit',
                             sortable: true,
-                            formatter: (value, key, item) => {
+                            formatter: (value) => {
                                 return this.getUnitName(value);
                             }
                         },
@@ -659,9 +659,9 @@
             ws_on_data(obj) {
                 if (obj.cmd != null) {
                     //console.log('websocket received command ' + obj.cmd);
-                    if (obj.cmd == 'insert') {
-                        var tom = new Date(obj.rec.data.tom.substring(0, 19));
-                        var rec = {
+                    if (obj.cmd === 'insert') {
+                        const tom = new Date(obj.rec.data.tom.substring(0, 19));
+                        let rec = {
                             pk: obj.rec.key.pk,
                             ident: obj.rec.data.ident,
                             meter: obj.rec.data.meter,
@@ -678,59 +678,59 @@
                             online: obj.rec.data.online
                         };
 
-                        if (obj.rec.data.online == 1) {
+                        if (obj.rec.data.online === 1) {
                             rec["_rowVariant"] = 'success';
                         }
-                        else if (obj.rec.data.online == 2) {
+                        else if (obj.rec.data.online === 2) {
                             rec["_rowVariant"] = 'warning';
                         }
                         //  insert into table
                         this.meters.push(rec);
                     }
-                    else if (obj.cmd == 'modify') {
+                    else if (obj.cmd === 'modify') {
                         //console.log('lookup meter ' + obj.key);
-                        self = this;
+                        const self = this;
                         this.meters.find(function (rec) {
-                            if (rec.pk == obj.key[0]) {
+                            if (rec.pk === obj.key[0]) {
                                 //console.log('modify meter ' + rec.ident);
                                 if (obj.value.ident != null) {
                                     rec.ident = obj.value.ident;
-                                    if (self.form.pk == obj.key[0]) self.form.ident = obj.value.ident;
+                                    if (self.form.pk === obj.key[0]) self.form.ident = obj.value.ident;
                                 }
                                 else if (obj.value.meter != null) {
                                     rec.meter = obj.value.meter;
-                                    if (self.form.pk == obj.key[0]) self.form.meter = obj.value.meter;
+                                    if (self.form.pk === obj.key[0]) self.form.meter = obj.value.meter;
                                 }
                                 else if (obj.value.code != null) {
                                     rec.code = obj.value.code;
-                                    if (self.form.pk == obj.key[0]) self.form.code = obj.value.code;
+                                    if (self.form.pk === obj.key[0]) self.form.code = obj.value.code;
                                 }
                                 else if (obj.value.maker != null) {
                                     rec.maker = obj.value.maker;
-                                    if (self.form.pk == obj.key[0]) self.form.maker = obj.value.maker;
+                                    if (self.form.pk === obj.key[0]) self.form.maker = obj.value.maker;
                                 }
                                 else if (obj.value.tom != null) {
                                     rec.tom = new Date(obj.value.tom.substring(0, 19));
                                 }
                                 else if (obj.value.vFirmware != null) {
                                     rec.fw = obj.value.vFirmware;
-                                    if (self.form.pk == obj.key[0]) self.form.fw = obj.value.vFirmware;
+                                    if (self.form.pk === obj.key[0]) self.form.fw = obj.value.vFirmware;
                                 }
                                 else if (obj.value.vParam != null) {
                                     rec.vParam = obj.value.vParam;
-                                    if (self.form.pk == obj.key[0]) self.form.vParam = obj.value.vParam;
+                                    if (self.form.pk === obj.key[0]) self.form.vParam = obj.value.vParam;
                                 }
                                 else if (obj.value.factoryNr != null) {
                                     rec.factoryNr = obj.value.factoryNr;
-                                    if (self.form.pk == obj.key[0]) self.form.factoryNr = obj.value.factoryNr;
+                                    if (self.form.pk === obj.key[0]) self.form.factoryNr = obj.value.factoryNr;
                                 }
                                 else if (obj.value.item != null) {
                                     rec.item = obj.value.item;
-                                    if (self.form.pk == obj.key[0]) self.form.item = obj.value.item;
+                                    if (self.form.pk === obj.key[0]) self.form.item = obj.value.item;
                                 }
                                 else if (obj.value.mClass != null) {
                                     rec.mClass = obj.value.mClass;
-                                    if (self.form.pk == obj.key[0]) self.form.mClass = obj.value.mClass;
+                                    if (self.form.pk === obj.key[0]) self.form.mClass = obj.value.mClass;
                                 }
                                 else if (obj.value.serverId != null) {
                                     rec.serverId = obj.value.serverId;
@@ -744,31 +744,39 @@
                             }
                         });
                     }
-                    else if (obj.cmd == 'clear') {
+                    else if (obj.cmd === 'clear') {
                         //  clear table
                         this.meters = [];
                     }
-                    else if (obj.cmd == 'delete') {
-                        // console.log('lookup meter ' + obj.key);
-                        var idx = this.meters.findIndex(rec => rec.pk == obj.key);
-                        // console.log('delete index ' + idx);
+                    else if (obj.cmd === 'delete') {
+                        const idx = this.meters.findIndex(rec => rec.pk === obj.key);
                         this.meters.splice(idx, 1);
                     }
-                    else if (obj.cmd == 'load') {
+                    else if (obj.cmd === 'load') {
                         //  load status
                         if (obj.show != null) {
                             //   console.log('load state ' + obj.show);
                             this.isBusy = obj.show;
                         }
-                        else if (obj.level != 0) {
+                        else if (obj.level !== 0) {
                             this.busyLevel = obj.level;
                         }
+
+                        if (obj.show === false) {
+                            // the table is loaded, we can select the meter - if there is one
+                            const meterPk = this.$route.params.meterPk;
+                            if (!meterPk){
+                                return;
+                            }
+                            const rowIndex = this.meters.findIndex(meter => meter.pk === meterPk);
+                            this.$refs.readoutTable.selectRow(rowIndex);
+                        }
                     }
-                    else if (obj.cmd == 'update') {
+                    else if (obj.cmd === 'update') {
                         console.log('update channel ' + obj.channel);
-                        if (obj.channel == 'attention.code') {
+                        if (obj.channel === 'attention.code') {
                             //   toasts/alerts
-                            if (obj.section == '8181c7c7fd00') {
+                            if (obj.section === '8181c7c7fd00') {
                                 //  OK
                                 this.$toasted.global.sml_attention_ok(obj.rec.srv + " modification accepted", "info");
                             }
@@ -782,17 +790,17 @@
                             this.spinner.push = false;
                             this.spinner.mirror = false;
                         }
-                        else if (obj.channel == MESSAGE_TYPES.getList) {
+                        else if (obj.channel === MESSAGE_TYPES.getList) {
                             //console.log(obj.rec.values);
                             //  hide spinner
                             this.spinner.readout = false;
                             // clear table
                             this.readout.values = [];
                             this.$toasted.global.sml_attention_ok(obj.rec.srv + " sent " + Object.keys(obj.rec.values).length + " values", "info");
-                            Object.keys(obj.rec.values.values).forEach((key, idx, a) => {
+                            Object.keys(obj.rec.values.values).forEach((key) => {
                                 //console.log(key);
                                 //console.log(obj.rec.values.values[key]);
-                                var rec = {
+                                const rec = {
                                     obis: key,
                                     value: obj.rec.values.values[key].value,
                                     unit: obj.rec.values.values[key].unit,
@@ -802,11 +810,11 @@
                                 this.readout.values.push(rec);
                             });
                         }
-                        else if (obj.channel == MESSAGE_TYPES.getProcParameter) {
+                        else if (obj.channel === MESSAGE_TYPES.getProcParameter) {
                             console.log(MESSAGE_TYPES.getProcParameter + ': ' + obj.section);
                             //console.log(obj.rec.values);
                             console.log(obj);
-                            if (obj.section == SML_CODES.CODE_ROOT_SENSOR_PARAMS) {
+                            if (obj.section === SML_CODES.CODE_ROOT_SENSOR_PARAMS) {
                                 this.spinner.meter = false;
                                 // aesKey: null
                                 // bitMask: "3030"
@@ -835,12 +843,12 @@
                                 this.tabMeter.data.user = obj.rec.values["8181613C01FF"];
                                 this.tabMeter.data.pwd = obj.rec.values["8181613C02FF"];
                             }
-                            else if (obj.section == SML_CODES.CODE_ROOT_DATA_COLLECTOR) {
+                            else if (obj.section === SML_CODES.CODE_ROOT_DATA_COLLECTOR) {
                                 this.spinner.mirror = false;
-                                Object.values(obj.rec.values).forEach((e, idx, a) => {
+                                Object.values(obj.rec.values).forEach((e, idx) => {
                                     //console.log(e);
 
-                                    var rec = {
+                                    const rec = {
                                         nr: idx + 1,
                                         active: e['8181C78621FF'],
                                         entries: e['8181C78622FF'],
@@ -855,11 +863,11 @@
                                 });
 
                             }
-                            else if (obj.section == SML_CODES.PUSH_OPERATIONS) {
+                            else if (obj.section === SML_CODES.PUSH_OPERATIONS) {
                                 this.spinner.push = false;
-                                Object.values(obj.rec.values).forEach((e, idx, a) => {
+                                Object.values(obj.rec.values).forEach((e, idx) => {
                                     console.log(e);
-                                    var rec = {
+                                    const rec = {
                                         nr: idx + 1,
                                         interval: e['8181C78A02FF'],
                                         delay: e['8181C78A03FF'],
@@ -991,7 +999,7 @@
             },
             onFiltered(filteredItems) {
                 // Trigger pagination to update the number of buttons/pages due to filtering
-                this.visibleRows = filteredItems.length
+                this.visibleRows = filteredItems.length;
                 this.currentPage = 1
             },
             getUnitName (code) {
@@ -1008,7 +1016,7 @@
                 return code;
             },
             getRegisterName(reg) {
-                var name = reg.toUpperCase();
+                const name = reg.toUpperCase();
                 if (name === '8181C78203FF') return "Hersteller-Identifikation";
                 else if (name === '8181C78205FF') return "öffentlicher Schlüssel";
                 else if (name === '810000090B00') return "Sekundenindex"; //  second index from meter
@@ -1064,10 +1072,10 @@
                 return "Refresh";
             },
             btnDeleteTitle() {
-                if (this.selected.length == 0) {
+                if (this.selected.length === 0) {
                     return "Delete";
                 }
-                else if (this.selected.length == 1) {
+                else if (this.selected.length === 1) {
                     return "Delete " + this.selected[0].ident;
                 }
                 return "Delete " + this.selected.length + " record(s)";
@@ -1080,21 +1088,21 @@
             },
             aesKeyValidation() {
                 if (this.tabMeter.data.aesKey == null) return true;
-                if (this.tabMeter.data.aesKey.length == 0) return true;
+                if (this.tabMeter.data.aesKey.length === 0) return true;
                 var rex = /[0-9A-Fa-f]{32}/g;   //  test for hexadecimal string
                 return rex.test(this.tabMeter.data.aesKey);
             },
             isOnline() {
-                if (this.selected.length == 0) return false;
+                if (this.selected.length === 0) return false;
 
                 var self = this;
                 var rec = this.meters.find(function (rec) {
                     //console.log(rec.pk + ' ? ' + self.form.pk);
-                    if (rec.pk == self.form.pk) return true;
+                    if (rec.pk === self.form.pk) return true;
                 });
                 //console.log(rec.pk + ' - ' + rec.ident + ' - ' + rec.online);
                 //  online state == 1
-                return (rec == null) ? true : (rec.online == 1);
+                return (rec == null) ? true : (rec.online === 1);
             }
         },
         beforeRouteEnter(to, from, next) {

--- a/src/views/smf-config-meter.vue
+++ b/src/views/smf-config-meter.vue
@@ -247,7 +247,7 @@
 
                                         <!-- A custom formatted column descr -->
                                             <template slot="obis" slot-scope="data">
-                                                <span v-b-popover.hover="data.item.value + ' ' + getUnitName(data.item.unit)" :title="getRegisterName(data.value)">{{ data.item.obis }}</span>
+                                                <span v-b-popover.hover="data.item.value + ' ' + getUnitName(data.item.unit)" :title="data.value | toRegisterName">{{ data.item.obis }}</span>
 <!--                                                <span v-b-popover.hover="data.value" :title="data.item.obis">{{ formatDescription(data.value) }}</span>-->
                                             </template>
 
@@ -633,7 +633,7 @@
                 tabDataMirror: {
                     data: {
                         items: []
-                        //items: [{nr:1, active: true, entries: 101, period: 3, OBIS:'8181c78614ff', name:'name'}]
+                        // items: [{nr:1, active: true, entries: 101, period: 3, OBIS:'8181c78614ff', name:'name'}]
                     }
                 },
                 //  loading state of SML data
@@ -1014,44 +1014,6 @@
                         break;
                 }
                 return code;
-            },
-            getRegisterName(reg) {
-                const name = reg.toUpperCase();
-                if (name === '8181C78203FF') return "Hersteller-Identifikation";
-                else if (name === '8181C78205FF') return "öffentlicher Schlüssel";
-                else if (name === '810000090B00') return "Sekundenindex"; //  second index from meter
-                else if (name === '0100000009FF') return "Geräteeinzelidentifikation";
-                else if (name === '0100000000FF') return "Identifikationsnummer 1.0 ServerId -> Seriennummer";
-                else if (name === '0000600100FF') return "Identifikationsnummer 2.1 Seriennummer";
-                else if (name === '0000601000FF') return "Geraetename";
-                else if (name === '0000616100FF') return "Fehlerregister";
-                else if (name === '0100010800FF') return "Zaehlerstand Totalregister";
-                else if (name === '0100010801FF') return "Zaehlerstand Tarif 1";
-                else if (name === '0100010802FF') return "Zaehlerstand Tarif 2";
-                else if (name === '0100100700FF') return "aktuelle Wirkleistung";
-                else if (name === '0100011100FF') return "letzter signierter Total-Zaehlerstand";
-                else if (name === '0100240700FF') return "Wirkleistung L1";
-                else if (name === '0100380700FF') return "Wirkleistung L2";
-                else if (name === '01004C0700FF') return "Wirkleistung L3";
-                else if (name === '010060320002') return "Aktuelle Chiptemperatur";
-                else if (name === '010060320003') return "Minimale Chiptemperatur";
-                else if (name === '010060320004') return "Maximale Chiptemperatur";
-                else if (name === '010060320005') return "Gemittelte Chiptemperatur";
-                else if (name === '010060320303') return "Spannungsminimum";
-                else if (name === '010060320304') return "Spannungsmaximum";
-                else if (name === '01001F0700FF') return "Strom L1";
-                else if (name === '0100200700FF') return "Spannung L1";
-                else if (name === '0100020800FF') return "negative Wirkenergie";
-                else if (name === '0100020801FF') return "negative Wirkenergie - Tarif 1";
-                else if (name === '0100020802FF') return "negative Wirkenergie - Tarif 2";
-                else if (name === '0100330700FF') return "Strom L2";
-                else if (name === '0100340700FF') return "Spannung L2";
-                else if (name === '0100470700FF') return "Strom L3";
-                else if (name === '0100480700FF') return "Spannung L3";
-                else if (name === '010000090B00') return "Zeitstempel (UTC)";
-                else if (name === '0700030000FF') return "Verbrauch in m³ (nicht korrigiert)";
-
-                return reg.toUpperCase();
             }
         },
 

--- a/src/views/smf-config-meter.vue
+++ b/src/views/smf-config-meter.vue
@@ -246,7 +246,7 @@
                                                  class="shadow">
 
                                         <!-- A custom formatted column descr -->
-                                            <template slot="obis" slot-scope="data">
+                                            <template v-slot:cell(obis)="data">
                                                 <span v-b-popover.hover="data.item.value + ' ' + getUnitName(data.item.unit)" :title="data.value | toRegisterName">{{ data.item.obis }}</span>
 <!--                                                <span v-b-popover.hover="data.value" :title="data.item.obis">{{ formatDescription(data.value) }}</span>-->
                                             </template>

--- a/src/views/smf-config-meter.vue
+++ b/src/views/smf-config-meter.vue
@@ -764,11 +764,11 @@
 
                         if (obj.show === false) {
                             // the table is loaded, we can select the meter - if there is one
-                            const meterPk = this.$route.params.meterPk;
-                            if (!meterPk){
+                            const meterIdent = this.$route.params.meterIdent;
+                            if (!meterIdent){
                                 return;
                             }
-                            const rowIndex = this.meters.findIndex(meter => meter.pk === meterPk);
+                            const rowIndex = this.meters.findIndex(meter => meter.ident === meterIdent);
                             this.$refs.readoutTable.selectRow(rowIndex);
                         }
                     }

--- a/src/views/smf-status-sessions.vue
+++ b/src/views/smf-status-sessions.vue
@@ -73,7 +73,7 @@
                     {{ data.index + 1 + (perPage * (currentPage - 1)) }}
                 </template>
 
-                <template slot="stop" slot-scope="row">
+                <template v-slot:cell(stop)="row">
                     <b-button size="sm"
                               variant="warning"
                               class="shadow"

--- a/src/views/smf-task-tsdb.vue
+++ b/src/views/smf-task-tsdb.vue
@@ -155,11 +155,11 @@
                     <template v-slot:cell(index)="data">{{ data.index + 1 }}</template>
 
                     <!-- row.item row.index -->
-                    <template slot="apply" slot-scope="row">
-  <!-- <b-button size="sm"> -->
-  {{calculateTotalHours(row.item.apply)}} h
-  <!-- </b-button> -->
-</template>
+                    <template v-slot:cell(apply)="row">
+                      <!-- <b-button size="sm"> -->
+                      {{calculateTotalHours(row.item.apply)}} h
+                      <!-- </b-button> -->
+                    </template>
 
                     <!-- loading slot -->
                     <div slot="table-busy" class="text-center text-danger">

--- a/tests/unit/.eslintrc.js
+++ b/tests/unit/.eslintrc.js
@@ -2,4 +2,4 @@ module.exports = {
   env: {
     jest: true
   }
-}
+};

--- a/tests/unit/localStorageMock.js
+++ b/tests/unit/localStorageMock.js
@@ -1,4 +1,4 @@
-var localStorageMock = (function() {
+const localStorageMock = (function() {
     var store = {};
     return {
         getItem: function(key) {

--- a/tests/unit/shared/formatter/registerNames.spec.ts
+++ b/tests/unit/shared/formatter/registerNames.spec.ts
@@ -1,0 +1,19 @@
+import {formatRegisterName} from '@/shared/formatter/registerNames';
+
+describe('registerNamesFormatter', () => {
+
+    it('should format a registername without the name', () => {
+        const formatted = formatRegisterName('010060320003');
+        expect(formatted).toEqual('Minimale Chiptemperatur');
+    });
+
+    it('should format a registername with the name', () => {
+        const formatted = formatRegisterName('010060320003', true);
+        expect(formatted).toEqual('010060320003 - Minimale Chiptemperatur');
+    });
+
+    it('should use the name if there is no human readable name configured', () => {
+        const formatted = formatRegisterName('0000a000');
+        expect(formatted).toEqual('0000A000');
+    });
+});


### PR DESCRIPTION
- as drill down parameter ident is used 
- the parameter will be present in the url as a route param - makes it possible to share the url and load the same meter
- fix the usage of the `template slot-scope=` is now `template v-slot:cell(apply)="row"`
- minor code cleanup
- new build target build-no-auth - will create a dist-no-auth.tar.gz at circle-ci