### PR TITLE
use meter pk to navigate form gateway to meters

### DIFF
--- a/src/mixins/web-socket.js
+++ b/src/mixins/web-socket.js
@@ -29,15 +29,17 @@ export const webSocket = {
 
     methods: {
         ws_open: function(path) {
+            const isSecure = window.location.protocol === 'https:';
+            const protocol = isSecure ? 'wss' : 'ws';
             this.path = path;
             var self = this; //  save context
             if (process.env.NODE_ENV === 'production') {
-                this.ws = new WebSocket('ws://' + location.host + path, ['SMF']);
+                this.ws = new WebSocket(`${protocol}://` + location.host + path, ['SMF']);
             }
             else {
                 // VUE_APP_SMF_SERVER can be set in the .env file
                 console.log('VUE_APP_SMF_SERVER: ' + process.env.VUE_APP_SMF_SERVER);
-                this.ws = new WebSocket(`ws://${ process.env.VUE_APP_SMF_SERVER || '192.168.1.21:8082'}/${path}`, ["SMF"]);
+                this.ws = new WebSocket(`${protocol}://${ process.env.VUE_APP_SMF_SERVER || '192.168.1.21:8082'}/${path}`, ["SMF"]);
             }
             this.ws.onopen = function() {
                 //  subscribe system status
@@ -240,7 +242,7 @@ export const webSocket = {
                 // this.ws = new WebSocket(this.path, ["SMF"]);
                 return;
             }
-            this.ws_emit_event_state("online");                
+            this.ws_emit_event_state("online");
             //  restart timer
             this.timer = setTimeout(this.onTimer, 5000);
         },

--- a/src/router.js
+++ b/src/router.js
@@ -61,7 +61,7 @@ export default new Router({
                 component: smfConfigGateway
             },
             {
-                path: "/config/meter/:meterIdent?",
+                path: "/config/meter/:meterPk?",
                 name: "smfConfigMeter",
                 component: smfConfigMeter
             },

--- a/src/views/smf-config-gateway.vue
+++ b/src/views/smf-config-gateway.vue
@@ -1910,7 +1910,7 @@ export default  {
             }
         },
         onMeterEdit(item) {
-           this.$router.push({ name: 'smfConfigMeter', params: { meterIdent: item.ident }});
+           this.$router.push({ name: 'smfConfigMeter', params: { meterPk: item.pk }});
         },
         onWMbusUpdate() {
             this.ws_submit_request(MESSAGE_TYPES.setProcParameter,

--- a/src/views/smf-config-meter.vue
+++ b/src/views/smf-config-meter.vue
@@ -783,12 +783,19 @@
 
                         if (obj.show === false) {
                             // the table is loaded, we can select the meter - if there is one
-                            const meterIdent = this.$route.params.meterIdent;
-                            if (!meterIdent) {
+                            const meterPk = this.$route.params.meterPk;
+                            const meterIsAvailable = this.meters.findIndex(meter => meter.pk === meterPk);
+                            if (meterIsAvailable === -1) {
                                 return;
                             }
-                            const rowIndex = this.meters.findIndex(meter => meter.ident === meterIdent);
-                            this.$refs.readoutTable.selectRow(rowIndex);
+                            // filter the table by the primary key - just in case there amount of meters is greate
+                            // than the page size (in this case the selected meter may not be visible.
+                            this.filter = meterPk;
+                            // wait a tick to let the view update itself and the table is filtered
+                            // after that the forst row must be the matching meter
+                            setTimeout(()=> {
+                                this.$refs.meterTable.selectRow(0);
+                            },1);
                         }
                     }
                     else if (obj.cmd === 'update') {


### PR DESCRIPTION
- the table will be filtered first and then the row is selected. this ensures the selected meter is visible if the meter table has more entries than one table page.